### PR TITLE
Fix Reading and Writing of Resources in Sub-Folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+vendor/
 .idea
 cmd/quiver_to_json/quiver_to_json
 cmd/quiver_to_markdown/quiver_to_markdown

--- a/cmd/quiver_to_json/main.go
+++ b/cmd/quiver_to_json/main.go
@@ -13,10 +13,9 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"os"
-
-	"flag"
 
 	"github.com/ushu/quiver"
 )

--- a/cmd/quiver_to_markdown/main.go
+++ b/cmd/quiver_to_markdown/main.go
@@ -10,24 +10,18 @@ Usage:
 package main
 
 import (
-	"fmt"
-	"os"
-
-	"path/filepath"
-
-	"strings"
-
 	"bufio"
-
-	"io/ioutil"
-
-	"regexp"
-
 	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/ushu/quiver"
-	"path"
 )
 
 // PathElementReplacer

--- a/cmd/quiver_to_markdown/main.go
+++ b/cmd/quiver_to_markdown/main.go
@@ -156,13 +156,12 @@ func writeNote(p string, note *quiver.Note, index NotesIndex) error {
 
 	// has resources ?
 	if len(note.Resources) > 0 {
-		rp := filepath.Join(path.Dir(p), "_resources")
-		err = EnsureDirectory(rp)
-		if err != nil {
-			return err
-		}
-
 		for _, r := range note.Resources {
+			rp := filepath.Join(path.Dir(p), "_resources", r.Rel)
+			err = EnsureDirectory(rp)
+			if err != nil {
+				return err
+			}
 			op := filepath.Join(rp, r.Name)
 			err = writeResource(op, r)
 			if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/ushu/quiver
+
+go 1.17
+
+require github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/quiver.go
+++ b/quiver.go
@@ -161,7 +161,7 @@ func (u *NoteResource) UnmarshalJSON(data []byte) error {
 
 	// Split data url
 	if !strings.HasPrefix(aux.URL, "data:") {
-		return fmt.Errorf("Invalid data URL %v", aux.URL)
+		return fmt.Errorf("invalid data URL %v", aux.URL)
 	}
 	s := strings.SplitN(aux.URL, ",", 2)
 	if len(s) != 2 {
@@ -247,11 +247,11 @@ func IsLibrary(path string) (bool, error) {
 		return false, err
 	}
 	if !stat.IsDir() {
-		return false, errors.New("The Quiver Library should be a dictionary")
+		return false, errors.New("the Quiver Library should be a dictionary")
 	}
 	// and end with .qvlibrary
 	if !strings.HasSuffix(stat.Name(), ".qvlibrary") {
-		return false, errors.New("The Quiver Library should have .qvlibrary extension")
+		return false, errors.New("the Quiver Library should have .qvlibrary extension")
 	}
 
 	return true, nil
@@ -362,11 +362,11 @@ func IsNotebook(path string) (bool, error) {
 		return false, err
 	}
 	if !stat.IsDir() {
-		return false, errors.New("A Quiver Notebook should be a directory")
+		return false, errors.New("a Quiver Notebook should be a directory")
 	}
 	// and end with .qvnotebook
 	if !strings.HasSuffix(stat.Name(), ".qvnotebook") {
-		return false, errors.New("A Quiver Notebook should have .qvnotebook extension")
+		return false, errors.New("a Quiver Notebook should have .qvnotebook extension")
 	}
 
 	return true, nil
@@ -420,11 +420,11 @@ func IsNote(path string) (bool, error) {
 		return false, err
 	}
 	if !stat.IsDir() {
-		return false, errors.New("A Quiver Note should be a directory")
+		return false, errors.New("a Quiver Note should be a directory")
 	}
 	// and end with .qvnote
 	if !strings.HasSuffix(stat.Name(), ".qvnote") {
-		return false, errors.New("A Quiver Note should have .qvnote extension")
+		return false, errors.New("a Quiver Note should have .qvnote extension")
 	}
 
 	return true, nil
@@ -472,7 +472,7 @@ func ReadNoteResources(path string) ([]*NoteResource, error) {
 		return nil, err
 	}
 	if !stat.IsDir() {
-		return nil, errors.New("Quiver Note Resources should be held in a directory")
+		return nil, errors.New("quiver Note Resources should be held in a directory")
 	}
 
 	files, err := ioutil.ReadDir(path)


### PR DESCRIPTION
I have noticed that notes that have folders as resources crashed the export to markdown. I also added a go.mod / .sum that the library is a go Module.

Therefore I implemented a fix to:

- read resources that are in a sub-folder(s). 
- remember the relativ path (basically the sub-folder(s))
- write resources back into sub-folder(s)

